### PR TITLE
base transition crash bugfix

### DIFF
--- a/Unit State Animator/Plugin/!unit-state-animator.js
+++ b/Unit State Animator/Plugin/!unit-state-animator.js
@@ -156,6 +156,7 @@ var UnitStateAnimator = {
 
     // call this function any time the unit custom parameters related to the icons change
     updateIcons: function() {
+	if(root.getCurrentScene() === SceneType.REST) return;
         this._iconArray = [];
 
         var enemies = EnemyList.getAliveList();


### PR DESCRIPTION
Former behavior: Map Complete event using Go to Base would crash on map transition.
New behavior: Checks current scene and skips code if in Base (SceneType.REST). Crash averted.